### PR TITLE
Switch to Dalamud.NET.Sdk, clean csproj, bump version in a single place

### DIFF
--- a/Bartender/Bartender.csproj
+++ b/Bartender/Bartender.csproj
@@ -1,21 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="Dalamud.Plugin.Bootstrap.targets" />
+<Project Sdk="Dalamud.NET.Sdk/12.0.2">
 
   <PropertyGroup>
-    <Version>1.1.6</Version>
     <Description>Save and load hotbar profiles with chat commands and/or macros.
 Allows for automation too!</Description>
     <PackageProjectUrl>https://github.com/RulHolos/Bartender</PackageProjectUrl>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>
     <IsPackable>false</IsPackable>
-    <AssemblyVersion>1.1.6</AssemblyVersion>
-    <FileVersion>1.1.6.0</FileVersion>
-    <AssemblyName>Bartender</AssemblyName>
-    <RootNamespace>Bartender</RootNamespace>
+    <AssemblyVersion>1.1.6.0</AssemblyVersion>
     <SignAssembly>False</SignAssembly>
     <RepositoryUrl>https://github.com/RulHolos/Bartender</RepositoryUrl>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,13 +32,5 @@ Allows for automation too!</Description>
     <Content Include="locals\fr.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="DalamudPackager" Version="12.0.0" />
-    <Reference Include="InteropGenerator.Runtime">
-      <Private>false</Private>
-      <HintPath>$(DalamudLibPath)InteropGenerator.Runtime.dll</HintPath>
-    </Reference>
   </ItemGroup>
 </Project>

--- a/Bartender/Bartender.csproj
+++ b/Bartender/Bartender.csproj
@@ -7,7 +7,7 @@ Allows for automation too!</Description>
     <PackageProjectUrl>https://github.com/RulHolos/Bartender</PackageProjectUrl>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>
     <IsPackable>false</IsPackable>
-    <AssemblyVersion>1.1.6.0</AssemblyVersion>
+    <AssemblyVersion>1.1.6.1</AssemblyVersion>
     <SignAssembly>False</SignAssembly>
     <RepositoryUrl>https://github.com/RulHolos/Bartender</RepositoryUrl>
   </PropertyGroup>

--- a/Bartender/Bartender.json
+++ b/Bartender/Bartender.json
@@ -1,12 +1,9 @@
 {
     "Author": "Rül Hölos",
     "Name": "Bartender",
-    "InternalName": "Bartender",
     "RepoUrl": "https://github.com/RulHolos/Bartender",
     "Punchline": "Save and load hotbars into profiles, re-use them later, profit.",
     "Description": "Save and load hotbars with macros and/or chat commands. We all need more than 10 hotbars, well now we do have those.",
-    "ApplicableVersion": "any",
-    "DalamudApiLevel": 12,
     "Tags": [
         "qol",
         "hotbar",

--- a/Bartender/packages.lock.json
+++ b/Bartender/packages.lock.json
@@ -7,6 +7,12 @@
         "requested": "[12.0.0, )",
         "resolved": "12.0.0",
         "contentHash": "J5TJLV3f16T/E2H2P17ClWjtfEBPpq3yxvqW46eN36JCm6wR+EaoaYkqG9Rm5sHqs3/nK/vKjWWyvEs/jhKoXw=="
+      },
+      "DotNet.ReproducibleBuilds": {
+        "type": "Direct",
+        "requested": "[1.2.25, )",
+        "resolved": "1.2.25",
+        "contentHash": "xCXiw7BCxHJ8pF6wPepRUddlh2dlQlbr81gXA72hdk4FLHkKXas7EH/n+fk5UCA/YfMqG1Z6XaPiUjDbUNBUzg=="
       }
     }
   }


### PR DESCRIPTION
- Stop using the plugin target bootstrap file - this has been deprecated
- Remove unneeded entries from plugin manifest - let DalamudPackager fill those in for you
- Remove extra version entries from csproj - You onyl really need assembly version. The rest will fill in from there.
